### PR TITLE
Putting parentheses in plume rise equation

### DIFF
--- a/src/plume_rise/sofiev_2012.jl
+++ b/src/plume_rise/sofiev_2012.jl
@@ -47,7 +47,7 @@ function Sofiev2012PlumeRise(; name = :Sofiev2012PlumeRise)
         N_ft(t), [unit = u"1/s", description = "Free troposphere Brunt-Vaisala frequency"]
     end
 
-    eqs = [H_p ~ α * H_abl + β * (P_fr / P_f0)^γ * exp(-δ * N_ft^2 / N_0^2) * H_scale]
+    eqs = [H_p ~ (α * H_abl + β * (P_fr / P_f0)^γ * exp(-δ * N_ft^2 / N_0^2)) * H_scale]
 
     return System(
         eqs, t, [H_abl, H_p, N_ft], [params1; params2];


### PR DESCRIPTION
Putting parentheses in the plume rise equation to apply H_scale to the whole equation.