### PR TITLE
Match new EarthSciData edge-indexed Z_agl convention in GEOSFP couplers

### DIFF
--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -58,18 +58,22 @@ function EarthSciMLBase.couple2(blm::BoundaryLayerMixingKCCoupler, g::GEOSFPCoup
     # Surface virtual temperature from already-connected BLM parameters
     Tv_sfc = b.T2M * (1 + 0.61 * b.QV2M)
 
-    # Pressure at mid-level from Ap/Bp hybrid coefficients
-    Pmid = _Pu_blm * Ap(ℓ + 0.5) + Bp(ℓ + 0.5) * b.PS
+    # Pressure at edge `ℓ` from Ap/Bp hybrid coefficients.  Matches GEOSFP's
+    # edge convention: ℓ=1 is the surface (P=PS), so Z_agl_expr is anchored
+    # at zero on the ground.  Tv_sfc is used as the layer-mean stand-in to
+    # keep this SDE-safe (no interpolator sampling at integer levels); the
+    # approximation is most accurate near the boundary layer, which is what
+    # BoundaryLayerMixingKC consumes.
+    P_at_lev = _Pu_blm * Ap(ℓ) + Bp(ℓ) * b.PS
 
-    # Hypsometric height AGL (using surface Tv as approximation for mean Tv)
-    Z_agl_expr = (_Rd_blm * Tv_sfc / _g_blm) * log(b.PS / Pmid)
+    Z_agl_expr = (_Rd_blm * Tv_sfc / _g_blm) * log(b.PS / P_at_lev)
 
     # dZ/dlev via pressure derivative (centered difference on Ap/Bp)
     Δℓ = 0.5
-    P_plus = _Pu_blm * Ap(ℓ + 0.5 + Δℓ) + Bp(ℓ + 0.5 + Δℓ) * b.PS
-    P_minus = _Pu_blm * Ap(ℓ + 0.5 - Δℓ) + Bp(ℓ + 0.5 - Δℓ) * b.PS
+    P_plus = _Pu_blm * Ap(ℓ + Δℓ) + Bp(ℓ + Δℓ) * b.PS
+    P_minus = _Pu_blm * Ap(ℓ - Δℓ) + Bp(ℓ - Δℓ) * b.PS
     dPdlev = (P_plus - P_minus) / (2 * Δℓ)
-    dZdlev_expr = -(_Rd_blm * Tv_sfc / _g_blm) * dPdlev / Pmid
+    dZdlev_expr = -(_Rd_blm * Tv_sfc / _g_blm) * dPdlev / P_at_lev
 
     return ConnectorSystem(
         [
@@ -189,42 +193,50 @@ function EarthSciMLBase.couple2(s12::Sofiev2012PlumeRiseCoupler, gfp::GEOSFPCoup
 
     softclamp = (x, lo, hi) -> ifelse(x < lo, lo, ifelse(x > hi, hi, x))
 
-    # Virtual potential temperature θv(ℓ) at hybrid mid-level ℓ
+    # Virtual potential temperature θv(ℓ) evaluated at simulation level ℓ.
+    # ℓ is the edge coordinate of the Ap/Bp tables (ℓ=1 is the surface);
+    # T/QV are sampled at the same ℓ — for non-integer ℓ this is the linear
+    # interpolation across the netCDF layer-center grid.
     θv_at = ℓ -> begin
-        T = T_itp(τ + t, λ, φ, ℓ)                           # [K]     temperature at mid-level ℓ
+        T = T_itp(τ + t, λ, φ, ℓ)                           # [K]     temperature at level ℓ
         qv = QV_itp(τ + t, λ, φ, ℓ)                          # [kg/kg] water-vapor mixing ratio at ℓ
         PS = PS_itp(τ + t, λ, φ)                             # [Pa]    surface pressure
-        P = Punit * Ap(ℓ + 0.5) + Bp(ℓ + 0.5) * PS          # [Pa]    hybrid mid-level pressure
+        P = Punit * Ap(ℓ) + Bp(ℓ) * PS                       # [Pa]    pressure at edge ℓ
         Tv = T * (1 + 0.61 * qv)                               # [K]     virtual temperature
         Tv * ((p0 * Punit) / P)^κ                            # [K]     virtual potential temperature θv
     end
 
-    # Geopotential height above ground Z(ℓ) via hypsometric
+    # Geopotential height above ground Z(ℓ) via a one-layer hypsometric
+    # approximation: Tv̄ ≈ ½(Tv(ℓ) + Tv_sfc) and a single ln(PS/P(ℓ)).  This
+    # is the same approximation Sofiev probes use over the lower troposphere
+    # — accurate near the PBL, degrading aloft.  Anchored at Z(1)=0 by the
+    # edge convention (matches gfp.Z_agl).
     Z_at = ℓ -> begin
-        Tv = T_itp(τ + t, λ, φ, ℓ) * (1 + 0.61 * QV_itp(τ + t, λ, φ, ℓ))   # [K]  virtual temp at mid-level ℓ
+        Tv = T_itp(τ + t, λ, φ, ℓ) * (1 + 0.61 * QV_itp(τ + t, λ, φ, ℓ))   # [K]  virtual temp at level ℓ
         Tv2 = T2M_itp(τ + t, λ, φ) * (1 + 0.61 * QV2M_itp(τ + t, λ, φ))   # [K]  virtual temp at 2 m
-        Tv̄ = 0.5 * (Tv + Tv2)                                               # [K]  layer-mean virtual temperature
+        Tv̄ = 0.5 * (Tv + Tv2)                                               # [K]  surface-to-ℓ mean Tv
         PS = PS_itp(τ + t, λ, φ)                                          # [Pa] surface pressure
-        Pmid = Punit * Ap(ℓ + 0.5) + Bp(ℓ + 0.5) * PS                       # [Pa] hybrid mid-level pressure
-        (Rd * Tv̄ / g) * log(PS / Pmid)                                      # [m]  hypsometric height AGL
+        P = Punit * Ap(ℓ) + Bp(ℓ) * PS                                     # [Pa] pressure at edge ℓ
+        (Rd * Tv̄ / g) * log(PS / P)                                        # [m]  hypsometric height AGL
     end
 
     # Map height H [m] → model level ℓ [-] via the exact GEOS-FP grid
     # inversion: height→pressure is analytic (hypsometric) and pressure→level
     # is the exact piecewise-linear inverse `lev_from_pressure`.  The layer-mean
     # virtual temperature Tv̄ depends weakly on ℓ, so a 2-pass fixed point is
-    # used, seeded from the 2-m virtual temperature.
+    # used, seeded from the 2-m virtual temperature.  Edge convention: ℓ=1 is
+    # the surface, so no half-level shift is applied to the inverted level.
     lev_from_height = H -> begin
         PS = PS_itp(τ + t, λ, φ)                                           # [Pa]
         Tv2 = T2M_itp(τ + t, λ, φ) * (1 + 0.61 * QV2M_itp(τ + t, λ, φ))     # [K] 2-m virtual temp
         # pass 1 — seed Tv̄ with the 2-m virtual temperature
         ℓ1 = softclamp(
-            lev_from_pressure(PS * exp(-g * H / (Rd * Tv2)), PS) - 0.5, LMIN, LMAX)
+            lev_from_pressure(PS * exp(-g * H / (Rd * Tv2)), PS), LMIN, LMAX)
         # pass 2 — refine Tv̄ as the surface-to-ℓ mean virtual temperature
         Tvℓ = T_itp(τ + t, λ, φ, ℓ1) * (1 + 0.61 * QV_itp(τ + t, λ, φ, ℓ1)) # [K]
         Tv̄ = 0.5 * (Tvℓ + Tv2)                                             # [K]
         softclamp(
-            lev_from_pressure(PS * exp(-g * H / (Rd * Tv̄)), PS) - 0.5, LMIN, LMAX)
+            lev_from_pressure(PS * exp(-g * H / (Rd * Tv̄)), PS), LMIN, LMAX)
     end
 
     return ConnectorSystem(
@@ -279,8 +291,10 @@ function EarthSciMLBase.couple2(gd::GaussianPGBCoupler, g::GEOSFPCoupler)
     Tv2 = T2M_itp(τ + t, λ, φ) * (1 + 0.61 * QV2M_itp(τ + t, λ, φ))
     Tv̄ = 0.5 * (Tv + Tv2)
     PS_v = PS_itp(τ + t, λ, φ)
-    Pmid = _Pu_pgb * Ap(ℓ + 0.5) + Bp(ℓ + 0.5) * PS_v
-    Z_agl_expr = (_Rd_pgb * Tv̄ / _g_pgb) * log(PS_v / Pmid)
+    # Edge convention (matches gfp.Z_agl): pressure at edge ℓ, ℓ=1 is the
+    # surface so Z_agl(1)=0.  Tv̄ kept as the 2-point average.
+    P_at_lev = _Pu_pgb * Ap(ℓ) + Bp(ℓ) * PS_v
+    Z_agl_expr = (_Rd_pgb * Tv̄ / _g_pgb) * log(PS_v / P_at_lev)
 
     return ConnectorSystem(
         [

--- a/test/plume_rise/sofiev_2012_test.jl
+++ b/test/plume_rise/sofiev_2012_test.jl
@@ -39,7 +39,11 @@
     prob = remake(prob, p = sol.prob.p)
     sol = solve(prob)
     lev_0 = sol[sys.Puff₊lev][1]
-    @test lev_0 ≈ 4.521111658242667
+    # Edge-indexed lev convention (EarthSciData PR #208): ℓ=1 is the surface
+    # in both gfp.Z_agl and the local Z_at/lev_from_height helpers, so the
+    # plume-top lev sits ~0.5 higher than under the previous midpoint-
+    # indexed convention (was 4.521).
+    @test lev_0 ≈ 5.09721934285556
 
     @test sol.retcode == SciMLBase.ReturnCode.Success
 end

--- a/test/puff_geosfp_gauss_test.jl
+++ b/test/puff_geosfp_gauss_test.jl
@@ -45,7 +45,10 @@
         sol = solve(prob, Tsit5())
 
         C_gl_val = sol[sys.GaussianPGB₊C_gl][end]
-        C_gl_want = 6.49e-11
+        # Edge-indexed Z_agl (EarthSciData PR #208): a puff at lev=1.4 now
+        # sits ~50 m AGL (40% into the first layer) instead of the previous
+        # ~125 m midpoint interpretation, so surface-level C_gl is higher.
+        C_gl_want = 8.209241335366349e-11
 
         @test isapprox(C_gl_val, C_gl_want; rtol = 0.02)
     end

--- a/test/puff_geosfp_test.jl
+++ b/test/puff_geosfp_test.jl
@@ -32,8 +32,8 @@
         [Symbol("Puff₊lon(t)"), Symbol("Puff₊lat(t)"), Symbol("Puff₊lev(t)")],
         Symbol.(unknowns(sys))
     )
-    @test length(parameters(sys)) == 706
-    @test length(observed(sys)) == 91
+    @test length(parameters(sys)) == 707
+    @test length(observed(sys)) == 89
 
     tspan = EarthSciMLBase.get_tspan(di)
     prob = ODEProblem(sys, [], tspan)


### PR DESCRIPTION
## Summary

Companion to [EarthSciData PR #208](https://github.com/EarthSciML/EarthSciData.jl/pull/208), which fixes a half-level inconsistency in `GEOSFP.Z_agl`: the pressure equation always used the edge convention (`P(lev=1) = PS`) but the height equation evaluated at `lev+0.5`, so the same `lev` simultaneously meant "surface" for pressure and "first-layer midpoint" for height. After the fix, `Z_agl(1) = 0` by construction and the formula is a proper cumulative hypsometric thickness up to the requested edge.

Three couplers in `EarthSciDataExt` carry their own duplicate `Z_agl` / `Z_at` expressions with the same `+0.5` half-level shift; they need to track the new convention so the `puff.lev` coordinate they consume/produce stays consistent across the GEOSFP boundary.

## Changes

- **`BoundaryLayerMixingKCCoupler`** — `Z_agl_expr` and `dZdlev_expr` now evaluate pressure at edge `ℓ` directly (no `+0.5` shift). `Tv_sfc` is retained as the layer-mean stand-in to keep this path SDE-safe (the new GEOSFP cumulative formula uses `build_interp_expr` at integer levels, which is incompatible with SDE compilation).
- **`Sofiev2012PlumeRiseCoupler`** — `θv_at(ℓ)`, `Z_at(ℓ)` and `lev_from_height(H)` all drop the `±0.5` shifts. The two-point `Tv̄ = ½(Tv(ℓ) + Tv_sfc)` approximation is kept; Sofiev's height probes (`z_ft ± Δz`) stay in the lower troposphere where the approximation is reasonable.
- **`GaussianPGBCoupler`** — `Z_agl_expr` drops the `+0.5` shift.

## Test value updates

These are semantic shifts under the new convention, not regressions:

- `Sofiev2012PlumeRise`: `lev_0` 4.521 → **5.097**. Same plume top altitude, but a half-layer-higher lev under the edge convention.
- `Puff GeosFP GaussianPGB`: `C_gl` 6.49e-11 → **8.21e-11**. A puff pinned at `lev=1.4` now sits ~50 m AGL (40 % into the first layer) instead of the previous ~125 m midpoint interpretation, so surface-level concentration is higher.
- `Puff GeosFP GaussianKC`: unchanged, already within its tolerance bounds.

## Test plan

- [x] `Sofiev2012PlumeRise` testitem — passes.
- [x] `Gaussian Dispersion` testitem (both `GaussianPGB` and `GaussianKC` testsets) — passes.
- [ ] Full `Pkg.test()` in CI.

## Depends on

- EarthSciML/EarthSciData.jl#208 must be merged and a compat-bumped EarthSciData release available before this can land cleanly. Pinned via `Manifest.toml` locally during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)