### PR TITLE
Advection mass-consistency: remove spurious −ϕ·div(u) source + lev-1 ground-flux leak

### DIFF
--- a/src/advection.jl
+++ b/src/advection.jl
@@ -113,7 +113,13 @@ function vf_z(args1, args2)
     data_f, grid1, grid2, grid3, Δ = args2
     x1 = grid1[i]
     x2 = grid2[j]
-    x3 = k > 1 ? grid3[min(k, length(grid3))] - Δ / 2 : grid3[k]
+    # Bottom face of cell k sits at lev = grid3[k] − Δ/2 for ALL k. The old
+    # `k > 1 ? … : grid3[k]` special-case sampled the cell CENTRE (grid3[1]=1.0)
+    # for the surface layer, i.e. OMEGA(lev 1.5)/2 ≠ 0 — a spurious mass flux
+    # THROUGH the ground. The regular formula gives lev 0.5, which is below the
+    # OMEGA source grid and is stored as exactly 0 by EarthSciData's
+    # `extrapolate_type = 0.0` guard: the intended no-flux-through-ground BC.
+    x3 = grid3[min(k, length(grid3))] - Δ / 2
     return data_f(p, t, x1, x2, x3) # Staggered grid
 end
 tuplefunc(vf) = (i, j, k, p, t) -> vf((i, j, k, p, t))

--- a/src/advection_stencils.jl
+++ b/src/advection_stencils.jl
@@ -171,6 +171,21 @@ The output will be time derivative of the central index (i.e. index 2)
 of the ϕ vector (i.e. dϕ/dt).
 
 `Δt` and `p` are not used, but are function arguments for consistency with other operators.
+
+ADVECTIVE (non-conservative) form. Transported quantities here are MIXING RATIOS,
+and the face winds `U` are independently interpolated GEOS-FP fields that do NOT
+satisfy discrete continuity (∂u/∂x+∂v/∂y+∂ω/∂p ≠ 0), especially over terrain
+where the horizontal differences are taken along sloping hybrid-σ level surfaces.
+The pure conservative flux form `(F_L−F_R)/Δ` therefore produces a SPURIOUS source
+`dϕ/dt = −ϕ·div(u)` for a uniform field — a chronic, terrain-locked, surface-peaked
+error that (via the positivity limiter) rectifies into non-physical O₃ runaway
+(observed: ~951 ppb over the Sierra Nevada / Rockies, identical across chemistry
+mechanisms). We subtract the divergence term `+ϕ[2]·(U[2]−U[1])/Δz` to recover the
+advective form `−u·∂ϕ/∂x`, which leaves a uniform mixing ratio EXACTLY unchanged.
+⚠ This trades strict mass conservation for stability/correctness of the mixing-ratio
+field; the fully correct fix is mass-coupled flux form (advect ϕ·Δp/g with a vertical
+mass flux re-diagnosed from horizontal-flux continuity, as GEOS-Chem/TPCORE does).
+See maintain/PR_DRAFTS/EnvironmentalTransport-31-advection-mass-consistency.md.
 """
 function upwind1_stencil(ϕ, U, Δt, Δz; p = nothing)
     sz = sign(Δz) # Handle negative grid spacing
@@ -180,7 +195,8 @@ function upwind1_stencil(ϕ, U, Δt, Δz; p = nothing)
     ur₋ = sz * min(sz * U[2], zero(eltype(U)))
     flux₊ = (ϕ[1] * ul₊ - ϕ[2] * ur₊) / Δz
     flux₋ = (ϕ[2] * ul₋ - ϕ[3] * ur₋) / Δz
-    return flux₊ + flux₋
+    div_correction = ϕ[2] * (U[2] - U[1]) / Δz   # flux → advective: kill −ϕ·div(u)
+    return flux₊ + flux₋ + div_correction
 end
 
 """


### PR DESCRIPTION
## Summary

`upwind1_stencil` (the only active advection stencil) applies **conservative flux form** `dϕ/dt = (F_L − F_R)/Δ` directly to **mixing ratios**, using three independently-interpolated GEOS-FP face winds that do **not** satisfy discrete continuity, with horizontal differences taken along terrain-following hybrid-σ surfaces. For a uniform field this leaves a spurious tendency `−ϕ·div(u) ≠ 0`.

In a CONUS GEOS-Chem run this produced **non-physical surface O₃ runaway** — ~10% of cells > 90 ppb, **max 951 ppb at lev-1**, profile decreasing upward, hotspots tracing the mountain ranges (Sierra/Rockies/Appalachians); identical between full-chem and SuperFast (so it's transport, not chemistry). A uniform-tracer unit test grows to ~1000 ppb-equiv.

A second, compounding defect: **lev-1 ground-flux leak** — `vf_z` sampled the surface layer's bottom face at the cell centre (`grid3[1]=1.0`) instead of the ground face (0.5), defeating EarthSciData's stored-0 no-flux-through-ground guard.

## Fix

1. `upwind1_stencil`: subtract the divergence term to recover **advective form** (`+ ϕ[2]*(U[2]−U[1])/Δz`). A uniform mixing ratio is left exactly unchanged; a real gradient still advects.
2. `vf_z`: drop the `k>1` special case so the surface bottom face samples lev 0.5 = the stored-0 no-flux guard.

## Verification

- Unit: uniform field → dϕ/dt = **2.8e-14** (was up to 1041); gradient still advects.
- End-to-end: the surface O₃ runaway is eliminated (a CONUS reference run went from max ~1224 ppb to ~50 ppb); 5-day spun-up surface O₃ vs EPA AQS lands at MFB −13.6% (matching published GEOS-Chem winter/spring benchmarks).

## Trade-off / follow-up

Advective form is the pragmatic fix — it is **non-conservative**. The fully correct fix is mass-coupled flux form (advect `ϕ·Δp/g` with the vertical mass flux re-diagnosed from column-integrated horizontal-flux continuity, GEOS-Chem/TPCORE-style), proposed as a follow-up. This PR removes the spurious source and the runaway now.

Found by an adversarial transport-stack audit + verified against a uniform-tracer conservation test. Cross-referenced from EarthSciML/GasChem.jl#225 (Stage 6).